### PR TITLE
containers now provides Lift instances

### DIFF
--- a/System/Console/Docopt/QQ/Instances.hs
+++ b/System/Console/Docopt/QQ/Instances.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DeriveLift#-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 
@@ -9,7 +10,11 @@ module System.Console.Docopt.QQ.Instances where
 
 import System.Console.Docopt.Types
 import Language.Haskell.TH.Syntax (Lift)
+
+#if !MIN_VERSION_containers(0,6,5)
 import Data.Map.Internal (Map(..))
 
 deriving instance Lift (Map Option OptionInfo)
+#endif
+
 deriving instance Lift (Docopt)


### PR DESCRIPTION
containers provides Lift instances as of its latest release. Don't create an instance for Map if we already have one. This fixes docopt to work the latest stackage snapshot.